### PR TITLE
Add simple file converter app

### DIFF
--- a/Css/style.css
+++ b/Css/style.css
@@ -1329,3 +1329,36 @@ li > .menu__container > .grid__controling .control_center--grid {
 .widgets-panel__calendar li span:first-child {
   font-weight: bold;
 }
+
+.file-converter {
+  display: none;
+  width: 22rem;
+  max-width: 90%;
+  height: 18rem;
+  background: var(--color-black-500);
+  backdrop-filter: blur(1rem);
+  border-radius: 1rem;
+  box-shadow: 0 0.5rem 2rem var(--color-black-500);
+  border: 1px solid var(--color-white-200);
+  padding: 1rem;
+}
+
+.file-converter__content {
+  height: calc(100% - 2rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.file-converter__content input,
+.file-converter__content select,
+.file-converter__content button {
+  width: 100%;
+}
+
+.file-converter__content a {
+  margin-top: 0.5rem;
+  color: #4aa3ff;
+}

--- a/index.html
+++ b/index.html
@@ -102,6 +102,9 @@
         <li class="leftLi app_name" id="map">
           <p>Maps</p>
         </li>
+        <li class="leftLi app_name" id="fileConverter">
+          <p>File Converter</p>
+        </li>
         <li class="leftLi">
           File
           <ul>
@@ -395,6 +398,10 @@
         />
         <hr class="point" id="point-terminal" />
       </button>
+      <button class="icon open-file-converter">
+        <img src="./icon/dock/appstore.png" alt="File Converter" />
+        <hr class="point hidden" id="point-file-converter" />
+      </button>
       <button class="icon">
         <img
           src="./icon/dock/preferences.png"
@@ -503,6 +510,10 @@
         <div class="child-launchpad" data-keywords="zoom,video,call">
           <img src="./icon/Launchpad/zoom.png" alt="" />
           <strong>Zoom</strong>
+        </div>
+        <div class="child-launchpad open-fileconverter-launching" data-keywords="File Converter">
+          <img src="./icon/Launchpad/appstore.png" alt="" />
+          <strong>File Converter</strong>
         </div>
       </div>
     </div>
@@ -658,6 +669,27 @@
           <button value="0" class="button number large">0</button>
           <button value="." class="button number">.</button>
           <button value="=" class="button operator r-radius">=</button>
+        </div>
+      </div>
+      <div class="window file-converter">
+        <div class="window__taskbar">
+          <div class="window__taskbar--actions">
+            <button class="close-file-converter"></button>
+            <button class="backfull-file-converter"></button>
+            <button class="full-file-converter"></button>
+          </div>
+          <div class="window__taskbar--content">
+            <h2>File Converter</h2>
+          </div>
+        </div>
+        <div class="content file-converter__content">
+          <input type="file" class="file-input" accept="image/*" />
+          <select class="format-select">
+            <option value="png">PNG</option>
+            <option value="jpeg">JPEG</option>
+          </select>
+          <button class="convert-btn">Convert</button>
+          <a href="#" class="download-link" style="display:none">Download</a>
         </div>
       </div>
     </div>

--- a/javascript/script.js
+++ b/javascript/script.js
@@ -83,6 +83,22 @@ const mapsApp = {
   opening: document.querySelector(".open-map"),
 };
 
+// File Converter App
+const fileConverterApp = {
+  app_name: document.querySelector("#fileConverter"),
+  window: document.querySelector(".file-converter"),
+  full: document.querySelector(".full-file-converter"),
+  close: document.querySelector(".close-file-converter"),
+  backfull: document.querySelector(".backfull-file-converter"),
+  point: document.querySelector("#point-file-converter"),
+  opening: document.querySelector(".open-file-converter"),
+  opening_l: document.querySelector(".open-fileconverter-launching"),
+  input: document.querySelector(".file-converter .file-input"),
+  format: document.querySelector(".file-converter .format-select"),
+  convertBtn: document.querySelector(".file-converter .convert-btn"),
+  downloadLink: document.querySelector(".file-converter .download-link"),
+};
+
 // Launchpad
 const launchpad = {
   container: document.querySelector(".container__Window"),
@@ -190,6 +206,16 @@ function handleLaunchpadSearch(e) {
 }
 // Launchpad function end
 
+function handleOpenFileConverter_launchpad() {
+  fileConverterApp.window.style.display = "block";
+  fileConverterApp.app_name.style.display = "block";
+  launchpad.container.style.display = "flex";
+  elements.navbar.style.display = "flex";
+  launchpad.window.style.display = "none";
+  fileConverterApp.point.style.display = "block";
+  launchpad.point.style.display = "none";
+}
+
 // Calculator app start
 function handleOpenCal_launchpad() {
   calculatorApp.window.style.display = "block";
@@ -220,6 +246,9 @@ notesApp.close.addEventListener("click", () =>
 mapsApp.close.addEventListener("click", () =>
   close_window(mapsApp.window, mapsApp.point, mapsApp.app_name)
 );
+fileConverterApp.close.addEventListener("click", () =>
+  close_window(fileConverterApp.window, fileConverterApp.point, fileConverterApp.app_name)
+);
 notesApp.deleting.addEventListener("click", handleDeleting);
 terminalApp.full.addEventListener("click", () =>
   handleFullScreen(terminalApp.window)
@@ -233,6 +262,9 @@ vscodeApp.full.addEventListener("click", () =>
 );
 */
 mapsApp.full.addEventListener("click", () => handleFullScreen(mapsApp.window));
+fileConverterApp.full.addEventListener("click", () =>
+  handleFullScreen(fileConverterApp.window)
+);
 notesApp.window.addEventListener("click", handleNotes);
 terminalApp.opening.addEventListener("click", () =>
   open_window(terminalApp.window, terminalApp.point, terminalApp.app_name)
@@ -243,6 +275,9 @@ notesApp.opening.addEventListener("click", () =>
 calculatorApp.opening.addEventListener("click", () =>
   open_window(calculatorApp.window, calculatorApp.point, calculatorApp.app_name)
 );
+fileConverterApp.opening.addEventListener("click", () =>
+  open_window(fileConverterApp.window, fileConverterApp.point, fileConverterApp.app_name)
+);
 /*
 vscodeApp.opening.addEventListener("click", () =>
   open_window(vscodeApp.window, vscodeApp.point, vscodeApp.app_name)
@@ -250,6 +285,10 @@ vscodeApp.opening.addEventListener("click", () =>
 */
 mapsApp.opening.addEventListener("click", () =>
   open_window(mapsApp.window, mapsApp.point, mapsApp.app_name)
+);
+fileConverterApp.opening_l.addEventListener(
+  "click",
+  handleOpenFileConverter_launchpad
 );
 /*
 vscodeApp.close.addEventListener("click", () =>
@@ -261,6 +300,9 @@ vscodeApp.backfull.addEventListener("click", () =>
 */
 mapsApp.backfull.addEventListener("click", () =>
   handleMinimize(mapsApp.window)
+);
+fileConverterApp.backfull.addEventListener("click", () =>
+  handleMinimize(fileConverterApp.window)
 );
 calculatorApp.close.addEventListener("click", () =>
   close_window(
@@ -346,6 +388,41 @@ $(function () {
   $(".Vscode").draggable();
   $(".spotlight_search").draggable();
   $(".maps").draggable();
+  $(".file-converter").draggable();
+});
+
+// File converter functionality
+fileConverterApp.convertBtn.addEventListener("click", () => {
+  const file = fileConverterApp.input.files[0];
+  if (!file) return;
+  const format = fileConverterApp.format.value;
+  const reader = new FileReader();
+  reader.onload = function (e) {
+    const img = new Image();
+    img.onload = function () {
+      const canvas = document.createElement("canvas");
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext("2d");
+      ctx.drawImage(img, 0, 0);
+      const mime = format === "jpeg" ? "image/jpeg" : "image/png";
+      canvas.toBlob(function (blob) {
+        const url = URL.createObjectURL(blob);
+        fileConverterApp.downloadLink.href = url;
+        fileConverterApp.downloadLink.download =
+          file.name.replace(/\.[^.]+$/, "") + "." + format;
+        fileConverterApp.downloadLink.textContent =
+          "Download " + format.toUpperCase();
+        fileConverterApp.downloadLink.style.display = "inline-block";
+      }, mime);
+    };
+    img.src = e.target.result;
+  };
+  reader.readAsDataURL(file);
+});
+
+fileConverterApp.input.addEventListener("change", () => {
+  fileConverterApp.downloadLink.style.display = "none";
 });
 
 // Date and time


### PR DESCRIPTION
## Summary
- add placeholder icons for a new File Converter app
- create File Converter window, dock icon, and launchpad entry
- implement UI styles for the converter
- add JavaScript to open/close the app and convert uploaded images to PNG/JPEG
- remove File Converter icon images from repository

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fc3d3e43883329b6c89bda2bb9e84