### PR TITLE
Add File Converter window without binary icons

### DIFF
--- a/Css/style.css
+++ b/Css/style.css
@@ -1329,3 +1329,19 @@ li > .menu__container > .grid__controling .control_center--grid {
 .widgets-panel__calendar li span:first-child {
   font-weight: bold;
 }
+
+.fileconverter {
+  display: none;
+  width: 30rem;
+  max-width: 90%;
+  height: 20rem;
+  max-height: 80%;
+  background: var(--app-color-white);
+  backdrop-filter: blur(1rem);
+  border-radius: 1rem;
+  box-shadow: 0 0.5rem 2rem var(--color-black-500);
+  border: 1px solid var(--color-white-200);
+  animation: zoom-out 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
+  padding: 1rem;
+}
+

--- a/Css/style.css
+++ b/Css/style.css
@@ -1330,18 +1330,35 @@ li > .menu__container > .grid__controling .control_center--grid {
   font-weight: bold;
 }
 
-.fileconverter {
+.file-converter {
   display: none;
-  width: 30rem;
+  width: 22rem;
   max-width: 90%;
-  height: 20rem;
-  max-height: 80%;
-  background: var(--app-color-white);
+  height: 18rem;
+  background: var(--color-black-500);
   backdrop-filter: blur(1rem);
   border-radius: 1rem;
   box-shadow: 0 0.5rem 2rem var(--color-black-500);
   border: 1px solid var(--color-white-200);
-  animation: zoom-out 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
   padding: 1rem;
 }
 
+.file-converter__content {
+  height: calc(100% - 2rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.file-converter__content input,
+.file-converter__content select,
+.file-converter__content button {
+  width: 100%;
+}
+
+.file-converter__content a {
+  margin-top: 0.5rem;
+  color: #4aa3ff;
+}

--- a/index.html
+++ b/index.html
@@ -102,6 +102,9 @@
         <li class="leftLi app_name" id="map">
           <p>Maps</p>
         </li>
+        <li class="leftLi app_name" id="fileconverter">
+          <p>File Converter</p>
+        </li>
         <li class="leftLi">
           File
           <ul>
@@ -383,6 +386,10 @@
         <img src="./icon/dock/calculator.png" alt="Calculator Logo" />
         <hr class="point" id="point-cal" />
       </button>
+        <button class="icon open-fileconverter">
+          <img src="./icon/dock/appstore.png" alt="File Converter Logo" />
+          <hr class="point hidden" id="point-fileconverter" />
+        </button>
       <button class="icon open-note">
         <img src="./icon/dock/notes.png" alt="Notes Logo" />
         <hr class="point hidden" id="point-note" />
@@ -442,6 +449,10 @@
           <img src="./icon/Launchpad/calculator.png" alt="" />
           <strong>Calculator</strong>
         </div>
+          <div class="child-launchpad open-fileconverter-launching" data-keywords="Converter,File">
+            <img src="./icon/Launchpad/appstore.png" alt="" />
+            <strong>Converter</strong>
+          </div>
         <div class="child-launchpad" data-keywords="Calendar">
           <img src="./icon/Launchpad/calendar.png" alt="" />
           <strong>Calendar</strong>
@@ -658,6 +669,21 @@
           <button value="0" class="button number large">0</button>
           <button value="." class="button number">.</button>
           <button value="=" class="button operator r-radius">=</button>
+        </div>
+      </div>
+      <div class="window fileconverter">
+        <div class="window__taskbar">
+          <div class="window__taskbar--actions">
+            <button class="close-fileconverter"></button>
+            <button class="backfull-fileconverter"></button>
+            <button class="full-fileconverter"></button>
+          </div>
+          <div class="window__taskbar--content">
+            <h2>File Converter</h2>
+          </div>
+        </div>
+        <div class="content">
+          <p>Convert your files here!</p>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
         <li class="leftLi app_name" id="map">
           <p>Maps</p>
         </li>
-        <li class="leftLi app_name" id="fileconverter">
+        <li class="leftLi app_name" id="fileConverter">
           <p>File Converter</p>
         </li>
         <li class="leftLi">
@@ -386,10 +386,6 @@
         <img src="./icon/dock/calculator.png" alt="Calculator Logo" />
         <hr class="point" id="point-cal" />
       </button>
-        <button class="icon open-fileconverter">
-          <img src="./icon/dock/appstore.png" alt="File Converter Logo" />
-          <hr class="point hidden" id="point-fileconverter" />
-        </button>
       <button class="icon open-note">
         <img src="./icon/dock/notes.png" alt="Notes Logo" />
         <hr class="point hidden" id="point-note" />
@@ -401,6 +397,10 @@
           class="hidden"
         />
         <hr class="point" id="point-terminal" />
+      </button>
+      <button class="icon open-file-converter">
+        <img src="./icon/dock/appstore.png" alt="File Converter" />
+        <hr class="point hidden" id="point-file-converter" />
       </button>
       <button class="icon">
         <img
@@ -449,10 +449,6 @@
           <img src="./icon/Launchpad/calculator.png" alt="" />
           <strong>Calculator</strong>
         </div>
-          <div class="child-launchpad open-fileconverter-launching" data-keywords="Converter,File">
-            <img src="./icon/Launchpad/appstore.png" alt="" />
-            <strong>Converter</strong>
-          </div>
         <div class="child-launchpad" data-keywords="Calendar">
           <img src="./icon/Launchpad/calendar.png" alt="" />
           <strong>Calendar</strong>
@@ -514,6 +510,10 @@
         <div class="child-launchpad" data-keywords="zoom,video,call">
           <img src="./icon/Launchpad/zoom.png" alt="" />
           <strong>Zoom</strong>
+        </div>
+        <div class="child-launchpad open-fileconverter-launching" data-keywords="File Converter">
+          <img src="./icon/Launchpad/appstore.png" alt="" />
+          <strong>File Converter</strong>
         </div>
       </div>
     </div>
@@ -671,19 +671,25 @@
           <button value="=" class="button operator r-radius">=</button>
         </div>
       </div>
-      <div class="window fileconverter">
+      <div class="window file-converter">
         <div class="window__taskbar">
           <div class="window__taskbar--actions">
-            <button class="close-fileconverter"></button>
-            <button class="backfull-fileconverter"></button>
-            <button class="full-fileconverter"></button>
+            <button class="close-file-converter"></button>
+            <button class="backfull-file-converter"></button>
+            <button class="full-file-converter"></button>
           </div>
           <div class="window__taskbar--content">
             <h2>File Converter</h2>
           </div>
         </div>
-        <div class="content">
-          <p>Convert your files here!</p>
+        <div class="content file-converter__content">
+          <input type="file" class="file-input" accept="image/*" />
+          <select class="format-select">
+            <option value="png">PNG</option>
+            <option value="jpeg">JPEG</option>
+          </select>
+          <button class="convert-btn">Convert</button>
+          <a href="#" class="download-link" style="display:none">Download</a>
         </div>
       </div>
     </div>

--- a/javascript/script.js
+++ b/javascript/script.js
@@ -83,6 +83,17 @@ const mapsApp = {
   opening: document.querySelector(".open-map"),
 };
 
+const fileConverterApp = {
+  app_name: document.querySelector("#fileconverter"),
+  window: document.querySelector(".fileconverter"),
+  full: document.querySelector(".full-fileconverter"),
+  close: document.querySelector(".close-fileconverter"),
+  backfull: document.querySelector(".backfull-fileconverter"),
+  point: document.querySelector("#point-fileconverter"),
+  opening: document.querySelector(".open-fileconverter"),
+  opening_l: document.querySelector(".open-fileconverter-launching"),
+};
+
 // Launchpad
 const launchpad = {
   container: document.querySelector(".container__Window"),
@@ -202,6 +213,16 @@ function handleOpenCal_launchpad() {
 }
 // Calculator app end
 
+function handleOpenConverter_launchpad() {
+  fileConverterApp.window.style.display = "block";
+  fileConverterApp.app_name.style.display = "block";
+  launchpad.container.style.display = "flex";
+  elements.navbar.style.display = "flex";
+  launchpad.window.style.display = "none";
+  fileConverterApp.point.style.display = "block";
+  launchpad.point.style.display = "none";
+}
+// Converter app end
 handleopen_spotlight();
 handleOpenLaunching();
 notesApp.adding.addEventListener("click", handleAdding);
@@ -243,6 +264,9 @@ notesApp.opening.addEventListener("click", () =>
 calculatorApp.opening.addEventListener("click", () =>
   open_window(calculatorApp.window, calculatorApp.point, calculatorApp.app_name)
 );
+fileConverterApp.opening.addEventListener("click", () =>
+  open_window(fileConverterApp.window, fileConverterApp.point, fileConverterApp.app_name)
+);
 /*
 vscodeApp.opening.addEventListener("click", () =>
   open_window(vscodeApp.window, vscodeApp.point, vscodeApp.app_name)
@@ -269,6 +293,20 @@ calculatorApp.close.addEventListener("click", () =>
     calculatorApp.app_name
   )
 );
+fileConverterApp.close.addEventListener("click", () =>
+  close_window(
+    fileConverterApp.window,
+    fileConverterApp.point,
+    fileConverterApp.app_name
+  )
+);
+fileConverterApp.backfull.addEventListener("click", () =>
+  handleMinimize(fileConverterApp.window)
+);
+fileConverterApp.full.addEventListener("click", () =>
+  handleFullScreen(fileConverterApp.window)
+);
+fileConverterApp.opening_l.addEventListener("click", handleOpenConverter_launchpad);
 calculatorApp.opening_l.addEventListener("click", handleOpenCal_launchpad);
 elements.open_spotlight.addEventListener("click", handleopen_spotlight);
 launchpad.searchbox.addEventListener("input", handleLaunchpadSearch);
@@ -346,6 +384,7 @@ $(function () {
   $(".Vscode").draggable();
   $(".spotlight_search").draggable();
   $(".maps").draggable();
+  $(".fileconverter").draggable();
 });
 
 // Date and time

--- a/javascript/script.js
+++ b/javascript/script.js
@@ -83,15 +83,20 @@ const mapsApp = {
   opening: document.querySelector(".open-map"),
 };
 
+// File Converter App
 const fileConverterApp = {
-  app_name: document.querySelector("#fileconverter"),
-  window: document.querySelector(".fileconverter"),
-  full: document.querySelector(".full-fileconverter"),
-  close: document.querySelector(".close-fileconverter"),
-  backfull: document.querySelector(".backfull-fileconverter"),
-  point: document.querySelector("#point-fileconverter"),
-  opening: document.querySelector(".open-fileconverter"),
+  app_name: document.querySelector("#fileConverter"),
+  window: document.querySelector(".file-converter"),
+  full: document.querySelector(".full-file-converter"),
+  close: document.querySelector(".close-file-converter"),
+  backfull: document.querySelector(".backfull-file-converter"),
+  point: document.querySelector("#point-file-converter"),
+  opening: document.querySelector(".open-file-converter"),
   opening_l: document.querySelector(".open-fileconverter-launching"),
+  input: document.querySelector(".file-converter .file-input"),
+  format: document.querySelector(".file-converter .format-select"),
+  convertBtn: document.querySelector(".file-converter .convert-btn"),
+  downloadLink: document.querySelector(".file-converter .download-link"),
 };
 
 // Launchpad
@@ -201,6 +206,16 @@ function handleLaunchpadSearch(e) {
 }
 // Launchpad function end
 
+function handleOpenFileConverter_launchpad() {
+  fileConverterApp.window.style.display = "block";
+  fileConverterApp.app_name.style.display = "block";
+  launchpad.container.style.display = "flex";
+  elements.navbar.style.display = "flex";
+  launchpad.window.style.display = "none";
+  fileConverterApp.point.style.display = "block";
+  launchpad.point.style.display = "none";
+}
+
 // Calculator app start
 function handleOpenCal_launchpad() {
   calculatorApp.window.style.display = "block";
@@ -213,16 +228,6 @@ function handleOpenCal_launchpad() {
 }
 // Calculator app end
 
-function handleOpenConverter_launchpad() {
-  fileConverterApp.window.style.display = "block";
-  fileConverterApp.app_name.style.display = "block";
-  launchpad.container.style.display = "flex";
-  elements.navbar.style.display = "flex";
-  launchpad.window.style.display = "none";
-  fileConverterApp.point.style.display = "block";
-  launchpad.point.style.display = "none";
-}
-// Converter app end
 handleopen_spotlight();
 handleOpenLaunching();
 notesApp.adding.addEventListener("click", handleAdding);
@@ -241,6 +246,9 @@ notesApp.close.addEventListener("click", () =>
 mapsApp.close.addEventListener("click", () =>
   close_window(mapsApp.window, mapsApp.point, mapsApp.app_name)
 );
+fileConverterApp.close.addEventListener("click", () =>
+  close_window(fileConverterApp.window, fileConverterApp.point, fileConverterApp.app_name)
+);
 notesApp.deleting.addEventListener("click", handleDeleting);
 terminalApp.full.addEventListener("click", () =>
   handleFullScreen(terminalApp.window)
@@ -254,6 +262,9 @@ vscodeApp.full.addEventListener("click", () =>
 );
 */
 mapsApp.full.addEventListener("click", () => handleFullScreen(mapsApp.window));
+fileConverterApp.full.addEventListener("click", () =>
+  handleFullScreen(fileConverterApp.window)
+);
 notesApp.window.addEventListener("click", handleNotes);
 terminalApp.opening.addEventListener("click", () =>
   open_window(terminalApp.window, terminalApp.point, terminalApp.app_name)
@@ -275,6 +286,10 @@ vscodeApp.opening.addEventListener("click", () =>
 mapsApp.opening.addEventListener("click", () =>
   open_window(mapsApp.window, mapsApp.point, mapsApp.app_name)
 );
+fileConverterApp.opening_l.addEventListener(
+  "click",
+  handleOpenFileConverter_launchpad
+);
 /*
 vscodeApp.close.addEventListener("click", () =>
   close_window(vscodeApp.window, vscodeApp.point, vscodeApp.app_name)
@@ -286,6 +301,9 @@ vscodeApp.backfull.addEventListener("click", () =>
 mapsApp.backfull.addEventListener("click", () =>
   handleMinimize(mapsApp.window)
 );
+fileConverterApp.backfull.addEventListener("click", () =>
+  handleMinimize(fileConverterApp.window)
+);
 calculatorApp.close.addEventListener("click", () =>
   close_window(
     calculatorApp.window,
@@ -293,20 +311,6 @@ calculatorApp.close.addEventListener("click", () =>
     calculatorApp.app_name
   )
 );
-fileConverterApp.close.addEventListener("click", () =>
-  close_window(
-    fileConverterApp.window,
-    fileConverterApp.point,
-    fileConverterApp.app_name
-  )
-);
-fileConverterApp.backfull.addEventListener("click", () =>
-  handleMinimize(fileConverterApp.window)
-);
-fileConverterApp.full.addEventListener("click", () =>
-  handleFullScreen(fileConverterApp.window)
-);
-fileConverterApp.opening_l.addEventListener("click", handleOpenConverter_launchpad);
 calculatorApp.opening_l.addEventListener("click", handleOpenCal_launchpad);
 elements.open_spotlight.addEventListener("click", handleopen_spotlight);
 launchpad.searchbox.addEventListener("input", handleLaunchpadSearch);
@@ -384,7 +388,41 @@ $(function () {
   $(".Vscode").draggable();
   $(".spotlight_search").draggable();
   $(".maps").draggable();
-  $(".fileconverter").draggable();
+  $(".file-converter").draggable();
+});
+
+// File converter functionality
+fileConverterApp.convertBtn.addEventListener("click", () => {
+  const file = fileConverterApp.input.files[0];
+  if (!file) return;
+  const format = fileConverterApp.format.value;
+  const reader = new FileReader();
+  reader.onload = function (e) {
+    const img = new Image();
+    img.onload = function () {
+      const canvas = document.createElement("canvas");
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext("2d");
+      ctx.drawImage(img, 0, 0);
+      const mime = format === "jpeg" ? "image/jpeg" : "image/png";
+      canvas.toBlob(function (blob) {
+        const url = URL.createObjectURL(blob);
+        fileConverterApp.downloadLink.href = url;
+        fileConverterApp.downloadLink.download =
+          file.name.replace(/\.[^.]+$/, "") + "." + format;
+        fileConverterApp.downloadLink.textContent =
+          "Download " + format.toUpperCase();
+        fileConverterApp.downloadLink.style.display = "inline-block";
+      }, mime);
+    };
+    img.src = e.target.result;
+  };
+  reader.readAsDataURL(file);
+});
+
+fileConverterApp.input.addEventListener("change", () => {
+  fileConverterApp.downloadLink.style.display = "none";
 });
 
 // Date and time


### PR DESCRIPTION
## Summary
- add placeholder icon for File Converter using existing appstore.png
- delete missing File Converter PNGs
- wire up new File Converter app actions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fc2ceb540833289652000d03400ea