### PR TITLE
Add install prompt for PWA

### DIFF
--- a/Css/style.css
+++ b/Css/style.css
@@ -1362,3 +1362,21 @@ li > .menu__container > .grid__controling .control_center--grid {
   margin-top: 0.5rem;
   color: #4aa3ff;
 }
+
+/* Add to Home Screen button */
+.install-btn {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  padding: 0.5rem 1rem;
+  background: var(--color-blue-800);
+  color: white;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  z-index: 10000;
+}
+
+.install-btn.install-hidden {
+  display: none;
+}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ https://mhmdmhd6.github.io/Mac-OS-Desktop
   <img width="300" src="https://user-images.githubusercontent.com/79286306/170665240-c8feef83-d6b0-41de-9368-ac15c7f4f0af.jpg">
 </p>
 
-                                      
+## Install on your phone
+
+Visit the website using a modern browser. When prompted, tap **Install App** or use your browser's *Add to Home Screen* option to create a shortcut.
 
 <hr> <br>
 

--- a/index.html
+++ b/index.html
@@ -728,6 +728,8 @@
       <input type="search" placeholder="Spotlight Search" />
     </div>
 
+    <button id="installBtn" class="install-btn install-hidden">Install App</button>
+
     <script src="./javascript/script.js"></script>
     <script src="./javascript/app.js"></script>
     

--- a/javascript/app.js
+++ b/javascript/app.js
@@ -10,3 +10,24 @@ if ("serviceWorker" in navigator) {
       console.log("Registration failed with " + error);
     });
 }
+
+let deferredPrompt;
+const installBtn = document.getElementById("installBtn");
+
+window.addEventListener("beforeinstallprompt", (e) => {
+  e.preventDefault();
+  deferredPrompt = e;
+  if (installBtn) {
+    installBtn.classList.remove("install-hidden");
+  }
+});
+
+installBtn?.addEventListener("click", () => {
+  installBtn.classList.add("install-hidden");
+  deferredPrompt?.prompt();
+});
+
+window.addEventListener("appinstalled", () => {
+  deferredPrompt = null;
+  installBtn?.classList.add("install-hidden");
+});


### PR DESCRIPTION
## Summary
- document how to install the site on mobile
- add PWA install button to the page
- style install button
- handle install prompt and appinstalled events

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fc947e7c883328870751409e704dd