### PR TITLE
Add text and PDF conversion support

### DIFF
--- a/index.html
+++ b/index.html
@@ -683,7 +683,7 @@
           </div>
         </div>
         <div class="content file-converter__content">
-          <input type="file" class="file-input" accept="image/*" />
+          <input type="file" class="file-input" accept="image/*,text/plain,application/pdf" />
           <div class="dimension-inputs">
             <input
               type="number"
@@ -702,6 +702,8 @@
             <option value="png">PNG</option>
             <option value="jpeg">JPEG</option>
             <option value="webp">WEBP</option>
+            <option value="pdf">PDF</option>
+            <option value="txt">TXT</option>
           </select>
           <button class="convert-btn">Convert</button>
           <a href="#" class="download-link" style="display:none">Download</a>
@@ -746,6 +748,9 @@
 
     <button id="installBtn" class="install-btn install-hidden">Install App</button>
 
+    <!-- External libraries for file conversion -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.12.313/pdf.min.js"></script>
     <script src="./javascript/script.js"></script>
     <script src="./javascript/app.js"></script>
     


### PR DESCRIPTION
## Summary
- extend file converter to accept text and PDF files
- support converting text files to PDF/TXT and PDF files to text
- update file input options
- load jsPDF and pdf.js libraries for conversion

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fce684eac8332ada7732bbef76e9a