### PR TITLE
Fix convert button missing in converter app

### DIFF
--- a/javascript/script.js
+++ b/javascript/script.js
@@ -103,6 +103,20 @@ const fileConverterApp = {
   status: document.querySelector(".file-converter .status-message"),
 };
 
+// Ensure convert button exists if HTML was missing it
+if (!fileConverterApp.convertBtn && fileConverterApp.window) {
+  const content = fileConverterApp.window.querySelector(
+    ".file-converter__content"
+  );
+  if (content) {
+    fileConverterApp.convertBtn = document.createElement("button");
+    fileConverterApp.convertBtn.className = "convert-btn";
+    fileConverterApp.convertBtn.textContent = "Convert";
+    content.appendChild(fileConverterApp.convertBtn);
+    fileConverterApp.convertBtn.addEventListener("click", handleFileConversion);
+  }
+}
+
 // Launchpad
 const launchpad = {
   container: document.querySelector(".container__Window"),
@@ -514,7 +528,9 @@ function handleFileConversion() {
   }
 }
 
-fileConverterApp.convertBtn.addEventListener("click", handleFileConversion);
+if (fileConverterApp.convertBtn) {
+  fileConverterApp.convertBtn.addEventListener("click", handleFileConversion);
+}
 
 fileConverterApp.input.addEventListener("change", () => {
   fileConverterApp.downloadLink.style.display = "none";


### PR DESCRIPTION
## Summary
- ensure `Convert` button exists in the file converter app by creating it if absent
- guard event listener setup so it won't fail when element is missing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fd16ddcc48332acbfe0aada131a51