### PR TITLE
Move requirements to webapp folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ https://mhmdmhd6.github.io/Mac-OS-Desktop
 
 Visit the website using a modern browser. When prompted, tap **Install App** or use your browser's *Add to Home Screen* option to create a shortcut.
 
+## Local setup
+
+Install Python dependencies using:
+
+```bash
+python -m pip install -r webapp/requirements.txt
+```
+
+
 <hr> <br>
 
 ## New Available features in this recent versions are: 😀

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -1,0 +1,2 @@
+flask>=2.2
+requests>=2.31


### PR DESCRIPTION
## Summary
- relocate Python `requirements.txt` into new `webapp/` folder
- update README local setup instructions to reference the moved file

## Testing
- `npm test` *(fails: Error: no test specified)*
- `python -m pip install -r webapp/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_683fe922a8708332b71acbf125b673ae